### PR TITLE
fix financial data download logic

### DIFF
--- a/ch09-risk/data/download-symbol-from-yahoo.sh
+++ b/ch09-risk/data/download-symbol-from-yahoo.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Client script to pull Yahoo Finance historical data, off of its new cookie
+# authenticated site. Start/End Date args can be any GNU readable dates.
+# Script requires: GNU date, head, curl and bash shell
+
+symbol=$1
+startDate=$2
+endDate=$3
+outputFile=$4
+
+startEpoch=$(date -d "$startDate" '+%s')
+endEpoch=$(date -d "$endDate" '+%s')
+
+cookieJar=$(mktemp)
+function cleanup() {
+    rm $cookieJar
+}
+trap cleanup EXIT
+
+function parseCrumb() {
+    tr "}" "\n" \
+        | grep CrumbStore \
+        | cut -d ":" -f 3 \
+        | sed 's+"++g'
+}
+
+function extractCrumb() {
+    crumbUrl="https://finance.yahoo.com/quote/$symbol?p=$symbol"
+    curl -s --cookie-jar $cookieJar $crumbUrl \
+        | parseCrumb
+}
+
+crumb=$(extractCrumb)
+if [ "$crumb" == "" ]
+then
+    echo "skip $symbol because of empty crumb"
+else
+    echo "download $symbol ..."
+    baseUrl="https://query1.finance.yahoo.com/v7/finance/download/"
+    args="$symbol?period1=$startEpoch&period2=$endEpoch&interval=1d&events=history"
+    crumbArg="&crumb=$crumb"
+    sheetUrl="$baseUrl$args$crumbArg"
+
+    tmpFile=$(mktemp)
+    function cleanupTempFile() {
+        rm $tmpFile
+    }
+    trap cleanupTempFile EXIT
+
+    curl -s --write-out "HTTPSTATUS:%{http_code}" --cookie $cookieJar --fail "$sheetUrl" > $tmpFile
+
+    # extract the status
+    HTTP_STATUS=$(cat $tmpFile | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
+
+    if [ ! $HTTP_STATUS -eq 200  ]; then
+        echo "skip $symbol because of http status($HTTP_STATUS) != 200"
+    else
+        # remove http_status line
+        head -n -1 $tmpFile > $outputFile
+    fi
+fi

--- a/ch09-risk/data/download-symbol.sh
+++ b/ch09-risk/data/download-symbol.sh
@@ -4,4 +4,4 @@
 #
 # See LICENSE file for further information.
 
-wget -O ${2}/${1}.csv "http://www.google.com/finance/historical?q=${1}&startdate=Jan+01%2C+2000&enddate=Dec+31%2C+2013&output=csv"
+./download-symbol-from-yahoo.sh ${1} "2000-01-01 00:00:00 UTC" "2013-12-31 23:59:59 UTC" ${2}/${1}.csv


### PR DESCRIPTION
since google finance doesn't work, i changed this to yahoo again.
script "ch09-risk/data/download-symbol-from-yahoo.sh" is downloading financial data from yahoo site and
because yahoo api doesn't always return http status code 200, i have to check this site return valid http status or not

i also remove readGoogleHistory method and restore readYahooHistory method.
Since downloaded file is ordered by date increasing order, i have to delete reverse.
Also in the downloaded file, some date have null values i have to ignore those dates by Try{}.toOption